### PR TITLE
HCK-8865: implemented schema version change for Swagger Schema FE

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -26,6 +26,8 @@ module.exports = {
 				security: modelSecurity,
 				securityDefinitions: modelSecurityDefinitions,
 			} = data.modelData[0];
+			const appTargetVersion = data?.options?.appTargetVersion;
+			const specVersion = appTargetVersion ?? dbVersion;
 
 			const resolveApiExternalRefs = data.options?.additionalOptions?.find(
 				option => option.id === 'resolveApiExternalRefs',
@@ -52,7 +54,7 @@ module.exports = {
 			const securityDefinitions = commonHelper.mapSecurityDefinitions(modelSecurityDefinitions);
 
 			const swaggerSchema = {
-				swagger: dbVersion,
+				swagger: specVersion,
 				info,
 				host,
 				basePath,

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -26,8 +26,8 @@ module.exports = {
 				security: modelSecurity,
 				securityDefinitions: modelSecurityDefinitions,
 			} = data.modelData[0];
-			const appTargetVersion = data?.options?.appTargetVersion;
-			const specVersion = appTargetVersion ?? dbVersion;
+			const apiTargetVersion = data?.options?.apiTargetVersion;
+			const specVersion = apiTargetVersion ?? dbVersion;
 
 			const resolveApiExternalRefs = data.options?.additionalOptions?.find(
 				option => option.id === 'resolveApiExternalRefs',

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -10,6 +10,7 @@ const utils = require('./utils/utils');
 const filtrationConfig = require('./utils/filtrationConfig');
 const mapJsonSchema = require('../reverse_engineering/helpers/adaptJsonSchema/mapJsonSchema');
 const handleReferencePath = require('./helpers/handleReferencePath');
+const versions = require('../package.json').contributes.target.versions;
 
 module.exports = {
 	generateModelScript(data, logger, cb) {
@@ -27,7 +28,7 @@ module.exports = {
 				securityDefinitions: modelSecurityDefinitions,
 			} = data.modelData[0];
 			const apiTargetVersion = data?.options?.apiTargetVersion;
-			const specVersion = apiTargetVersion ?? dbVersion;
+			const specVersion = apiTargetVersion && versions.includes(apiTargetVersion) ? apiTargetVersion : dbVersion;
 
 			const resolveApiExternalRefs = data.options?.additionalOptions?.find(
 				option => option.id === 'resolveApiExternalRefs',


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8865" title="HCK-8865" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8865</a>  OpenAPI model version selection without template
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added support for explicit choice of Swagger schema version instead of template